### PR TITLE
Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 # You can get/create one here :
 # https://www.twilio.com/console/authy/applications
-ACCOUNT_SECURITY_API_KEY=ENTER_SECRET_HERE
+export ACCOUNT_SECURITY_API_KEY=ENTER_SECRET_HERE


### PR DESCRIPTION
'source .env' didn't work for me and found this solution here https://stackoverflow.com/questions/19331497/set-environment-variables-from-file-of-key-pair-values
another solution would be to run 'set -o allexport' before 'source .env' but I think export is cleaner and simmilar to the way it's done for node example